### PR TITLE
Update lcsr_wam_sim.rosinstall

### DIFF
--- a/applications/lcsr_wam_sim.rosinstall
+++ b/applications/lcsr_wam_sim.rosinstall
@@ -12,5 +12,7 @@
 - git: {local-name: underlay/src/barrett_model, uri: 'git@github.com:jhu-lcsr/barrett_model.git'}
 - git: {local-name: underlay/src/lcsr_robot_models, uri: 'git@github.com:jhu-lcsr/lcsr_robot_models.git'}
 - git: {local-name: underlay/src/lcsr_controllers, uri: 'git@github.com:jhu-lcsr/lcsr_controllers.git'}
+- git: {local-name: underlay/src/cartesian_trajectory_msgs, uri: 'git@github.com:jhu-lcsr/cartesian_trajectory_msgs.git'}
+- git: {local-name: underlay/src/lcsr_telemanip, uri: 'git@github.com:jhu-lcsr/lcsr_telemanip.git'}
 - git: {local-name: underlay/src/lcsr_barrett, uri: 'git@github.com:jhu-lcsr/lcsr_barrett.git'}
 - git: {local-name: underlay/src/conman, uri: 'git@github.com:jbohren/conman.git'}


### PR DESCRIPTION
lcsr_telemanip and cartesian_trajectory_msgs are required for installing the Wam simulator but were not previously included here.
